### PR TITLE
Fixed TX power control and RPi build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ CONFIG_RTW_DEBUG = n
 CONFIG_RTW_LOG_LEVEL = 2
 
 # enable /proc/net/rtlxxxx/ debug interfaces
-CONFIG_PROC_DEBUG = n
+CONFIG_PROC_DEBUG = y
 
 ######################## Wake On Lan ##########################
 CONFIG_WOWLAN = n
@@ -121,6 +121,8 @@ CONFIG_RTW_SDIO_PM_KEEP_POWER = y
 CONFIG_MP_VHT_HW_TX_MODE = n
 ###################### Platform Related #######################
 CONFIG_PLATFORM_I386_PC = y
+CONFIG_PLATFORM_ARM_RPI = n
+CONFIG_PLATFORM_ARM64 = n
 CONFIG_PLATFORM_ANDROID_X86 = n
 CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
 CONFIG_PLATFORM_JB_X86 = n
@@ -1298,6 +1300,29 @@ MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 INSTALL_PREFIX :=
 STAGINGMODDIR := /lib/modules/$(KVER)/kernel/drivers/staging
 endif
+
+ifeq ($(CONFIG_PLATFORM_ARM_RPI), y)
+EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+ARCH ?= arm
+CROSS_COMPILE ?=
+KVER ?= $(shell uname -r)
+KSRC := /lib/modules/$(KVER)/build
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+INSTALL_PREFIX :=
+endif
+
+ifeq ($(CONFIG_PLATFORM_ARM64), y)
+ARCH := arm64
+EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+CROSS_COMPILE := aarch64-linux-gnu-
+KVER ?= $(shell uname -r)
+KSRC := /lib/modules/$(KVER)/build
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+INSTALL_PREFIX :=
+endif
+
 
 ifeq ($(CONFIG_PLATFORM_NV_TK1), y)
 EXTRA_CFLAGS += -DCONFIG_PLATFORM_NV_TK1

--- a/hal/rtl8814a/rtl8814a_dm.c
+++ b/hal/rtl8814a/rtl8814a_dm.c
@@ -288,7 +288,7 @@ void rtl8814_init_dm_priv(PADAPTER Adapter)
 
 	Init_ODM_ComInfo_8814(Adapter);
 	odm_init_all_timers(podmpriv);
-	//pHalData->CurrentTxPwrIdx = 13;
+	pHalData->CurrentTxPwrIdx = 20;
 }
 
 void rtl8814_deinit_dm_priv(PADAPTER Adapter)

--- a/hal/rtl8814a/rtl8814a_phycfg.c
+++ b/hal/rtl8814a/rtl8814a_phycfg.c
@@ -593,6 +593,46 @@ PHY_RFConfig8814A(
 /* 1 5. Tx  Power setting API */
 
 void
+phy_TxPwrAdjInPercentage(
+	PADAPTER		Adapter,
+	s16*			pTxPwrIdx)
+{
+	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(Adapter);
+	int txPower = *pTxPwrIdx + pHalData->CurrentTxPwrIdx - 18;
+
+	*pTxPwrIdx = txPower > RF6052_MAX_TX_PWR ? RF6052_MAX_TX_PWR : txPower;
+}
+
+
+#if 0 //unused?
+void
+PHY_GetTxPowerLevel8814(
+	IN	PADAPTER		Adapter,
+	OUT s32*    		powerlevel
+	)
+{
+	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(Adapter);
+	*powerlevel = pHalData->CurrentTxPwrIdx;
+#if 0
+	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(Adapter);
+	PMGNT_INFO		pMgntInfo = &(Adapter->MgntInfo);
+	s4Byte			TxPwrDbm = 13;
+
+	if ( pMgntInfo->ClientConfigPwrInDbm != UNSPECIFIED_PWR_DBM )
+		*powerlevel = pMgntInfo->ClientConfigPwrInDbm;
+	else
+		*powerlevel = TxPwrDbm;
+#endif //0
+/*
+	//PMPT_CONTEXT            pMptCtx = &(Adapter->mppriv.mpt_ctx);
+	//u8 mgn_rate = mpt_to_mgnt_rate(HwRateToMPTRate(Adapter->mppriv.rateidx));
+	*powerlevel=PHY_GetTxPowerIndex8814A(Adapter,RF_PATH_A ,MGN_MCS7, pHalData->current_channel_bw, pHalData->current_channel, NULL);
+	*powerlevel/=2;
+*/
+}
+#endif
+
+void
 PHY_SetTxPowerLevel8814(
 		PADAPTER		Adapter,
 		u8			Channel
@@ -675,6 +715,9 @@ PHY_GetTxPowerIndex8814A(
 	CCX_CellPowerLimit(pAdapter, Channel, Rate, &power_idx);
 #endif
 #endif
+
+
+	phy_TxPwrAdjInPercentage(pAdapter, &power_idx);
 
 	if (power_idx < 0)
 		power_idx = 0;

--- a/include/hal_data.h
+++ b/include/hal_data.h
@@ -532,6 +532,7 @@ typedef struct hal_com_data {
 	u8	txpwr_limit_loaded:1;
 	u8	txpwr_limit_from_file:1;
 	u8	rf_power_tracking_type;
+	u8	CurrentTxPwrIdx;
 
 	/* Read/write are allow for following hardware information variables	 */
 	u8	crystal_cap;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4231,6 +4231,30 @@ static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
 	enum tx_power_setting type, int dbm)
 #endif
 {
+
+	// Set TXPower code from aircrack-ng 5.6.4.2
+
+	_adapter *padapter = wiphy_to_adapter(wiphy);
+	HAL_DATA_TYPE   *pHalData = GET_HAL_DATA(padapter);
+	int value;
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,36)) || defined(COMPAT_KERNEL_RELEASE)
+		value = mbm/100;
+	#else
+		value = dbm;
+	#endif
+
+	// Limits to '4000mw'
+	if(value < 0)
+		value = 0;
+	if(value > 40)
+		value = 40;
+
+	if(type == NL80211_TX_POWER_FIXED) {
+		pHalData->CurrentTxPwrIdx = value;
+		rtw_hal_set_tx_power_level(padapter, pHalData->current_channel);
+	} else
+		return -EOPNOTSUPP;
+
 #if 0
 	struct iwm_priv *iwm = wiphy_to_iwm(wiphy);
 	int ret;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4291,9 +4291,12 @@ static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
 #endif
 	int *dbm)
 {
+	_adapter *padapter = wiphy_to_adapter(wiphy);
+	HAL_DATA_TYPE *pHalData = GET_HAL_DATA(padapter);
+
 	RTW_INFO("%s\n", __func__);
 
-	*dbm = (20);
+	*dbm = pHalData->CurrentTxPwrIdx;
 
 	return 0;
 }


### PR DESCRIPTION
Fixed TXPower (and RPi makefile options)
e.g.
`iw dev {x} set txpower fixed ( 0 ... 4000 ) 
`
(Note that 4000 should be read as "100% of whatever the card feels is full power"; the concept of actual dBm is meaningless here)

Power does actually change (verified against an AP), works same as previous driver.

All fix code copied in verbatim from aircrack / 88XXAU

