### PR TITLE
Fix ARMv7 build and avoid sbsigntool depdency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: rtl8814au
 Section: kernel
 Priority: optional
 Maintainer: jimmy <jimmy@jimmy-alpha>
-Build-Depends: debhelper (>=9), dkms, git, sed, sbsigntool
+Build-Depends: debhelper (>=9), dkms, git, sed
 Standards-Version: 3.9.6
 Homepage: http://www.realtek.com.tw/
 Vcs-Git: https://github.com/coolshou/rtl8814au.git
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/coolshou/rtl8814au
 
 Package: rtl8814au-dkms
 Architecture: all
-Depends: ${misc:Depends}, dkms, linux-libc-dev, libc6-dev, sbsigntool
+Depends: ${misc:Depends}, dkms, linux-libc-dev, libc6-dev
 XB-Modaliases: ${modaliases}
 Description: dkms source for the rtl8814au network driver
  rtl8814au is the Linux device driver released for the RealTek RTL8814AU WiFi

--- a/debian/rtl8814au-dkms.dkms
+++ b/debian/rtl8814au-dkms.dkms
@@ -1,7 +1,9 @@
 PACKAGE_NAME="rtl8814au"
 PACKAGE_VERSION="#MODULE_VERSION#"
 BUILT_MODULE_NAME[0]="8814au"
-MAKE="'make' clean; 'make' all;kmodsign sha512 MOK.priv MOK.der 8814au.ko"
+PROCS_NUM=$parallel_jobs
+[ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
+MAKE="'make' clean; 'make' -j$PROCS_NUM KVER=${kernelver} KSRC=/lib/modules/${kernelver}/build all; if [[ -x /usr/sbin/kmodsign ]]; then kmodsign sha512 MOK.priv MOK.der 8814au.ko; fi"
 CLEAN="'make' clean"
 DEST_MODULE_LOCATION[0]="/updates/dkms"
 AUTOINSTALL="YES"


### PR DESCRIPTION
Hi,

I've used this driver on x86 almost without problems. But moving to ARMv7 system, Odroid XU4, I've noticed that I can't compile the DKMS driver.

There are 2 thinks I've changed:

1. Adding parallel jobs for building.
2. Removing the dependency for sbsigntool and add a check for "/usr/sbin/kmodsign" in MAKE line to sign the module in case is needed.

On ARM platforms is not 100% mandatory to sign the driver.