### PR TITLE
Enabled LED control via led_ctrl interface, fix 5.11 compilation and a potential memory leak resulting in disconnections

### DIFF
--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4802,9 +4802,9 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 		rtw_mfree(source, 2048);
 	}
 #ifdef set_fs
-	set_fs(fs);
-	filp_close(fp, NULL);
+	set_fs(fs);	
 #endif
+	filp_close(fp, NULL);
 	RTW_INFO("-%s-\n", __func__);
 	return 0;
 }

--- a/hal/led/hal_usb_led.c
+++ b/hal/led/hal_usb_led.c
@@ -4139,7 +4139,8 @@ LedControlUSB(
 		return;
 	}
 
-	if (ledpriv->bRegUseLed == _FALSE)
+	if (ledpriv->bRegUseLed == _FALSE ||
+	    padapter->registrypriv.led_ctrl == 0)
 		return;
 
 	/* if(priv->bInHctTest) */

--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -225,6 +225,9 @@ struct registry_priv {
 #ifdef CONFIG_TX_EARLY_MODE
 	u8   early_mode;
 #endif
+#ifdef CONFIG_RTW_SW_LED
+	u8   led_ctrl;
+#endif
 #ifdef CONFIG_NARROWBAND_SUPPORTING
 	u8	rtw_nb_config;
 #endif

--- a/include/rtw_debug.h
+++ b/include/rtw_debug.h
@@ -569,6 +569,11 @@ ssize_t proc_set_mcc_sta_bw80_target_tp(struct file *file, const char __user *bu
 int proc_get_mcc_policy_table(struct seq_file *m, void *v);
 #endif /* CONFIG_MCC_MODE */
 
+#ifdef CONFIG_RTW_SW_LED
+int proc_get_led_ctrl(struct seq_file *m, void *v);
+ssize_t proc_set_led_ctrl(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data);
+#endif /* CONFIG_RTW_SW_LED */
+
 int proc_get_ack_timeout(struct seq_file *m, void *v);
 ssize_t proc_set_ack_timeout(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data);
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -460,7 +460,7 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
 	if (started) {
-		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, true);
+		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0);
 		goto exit;
 	}
 #endif

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -460,7 +460,7 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
 	if (started) {
-		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0);
+		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, true);
 		goto exit;
 	}
 #endif

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -464,7 +464,14 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
 		goto exit;
 	}
 #endif
-
+	
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
+	if (started) {
+		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, true);
+		goto exit;
+	}
+#endif
+	
     if (!rtw_cfg80211_allow_ch_switch_notify(adapter))
         	goto exit;
 		cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -460,14 +460,11 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
 	if (started) {
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
+		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, false);
+	#else
 		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0);
-		goto exit;
-	}
-#endif
-	
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
-	if (started) {
-		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, true);
+	#endif
 		goto exit;
 	}
 #endif

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -150,6 +150,10 @@ int rtw_check_fw_ps = 1;
 int rtw_early_mode = 1;
 #endif
 
+#ifdef CONFIG_RTW_SW_LED
+int rtw_led_ctrl = 1; // default to normal blink
+#endif
+
 int rtw_usb_rxagg_mode = 2;/* RX_AGG_DMA=1, RX_AGG_USB=2 */
 module_param(rtw_usb_rxagg_mode, int, 0644);
 
@@ -569,6 +573,12 @@ module_param(rtw_pci_aspm_enable, int, 0644);
 #ifdef CONFIG_TX_EARLY_MODE
 module_param(rtw_early_mode, int, 0644);
 #endif
+
+#ifdef CONFIG_RTW_SW_LED
+module_param(rtw_led_ctrl, int, 0644);
+MODULE_PARM_DESC(rtw_led_ctrl,"Led Control: 0=Always off, 1=Normal blink, 2=Always on");
+#endif
+
 #ifdef CONFIG_ADAPTOR_INFO_CACHING_FILE
 char *rtw_adaptor_info_caching_file_path = "/data/misc/wifi/rtw_cache";
 module_param(rtw_adaptor_info_caching_file_path, charp, 0644);
@@ -1206,6 +1216,9 @@ uint loadparam(_adapter *padapter)
 
 #ifdef CONFIG_TX_EARLY_MODE
 	registry_par->early_mode = (u8)rtw_early_mode;
+#endif
+#ifdef CONFIG_RTW_SW_LED
+	registry_par->led_ctrl = (u8)rtw_led_ctrl;
 #endif
 	registry_par->lowrate_two_xmit = (u8)rtw_lowrate_two_xmit;
 	registry_par->rf_path = (u8)rtw_rf_path; /*rf_config/rtw_rf_config*/

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -4559,6 +4559,10 @@ const struct rtw_proc_hdl adapter_proc_hdls[] = {
 #endif
 
 	RTW_PROC_HDL_SSEQ("cur_beacon_keys", proc_get_cur_beacon_keys, NULL),
+
+#ifdef CONFIG_RTW_SW_LED
+	RTW_PROC_HDL_SSEQ("led_ctrl", proc_get_led_ctrl, proc_set_led_ctrl),
+#endif
 };
 
 const int adapter_proc_hdls_num = sizeof(adapter_proc_hdls) / sizeof(struct rtw_proc_hdl);


### PR DESCRIPTION
Accessible via proc interface and during module loading via paramter rtw_led_ctrl=0
Code merged from aircrack rtl8812au driver, which had working LED control until 8814au was split off