### PR TITLE
Fix GRO_DROP deprecation in Linux v5.12.

### DIFF
--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -355,8 +355,13 @@ static int napi_recv(_adapter *padapter, int budget)
 
 #ifdef CONFIG_RTW_GRO
 		if (pregistrypriv->en_gro) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
 			if (rtw_napi_gro_receive(&padapter->napi, pskb) != GRO_DROP)
 				rx_ok = _TRUE;
+#else
+			rtw_napi_gro_receive(&padapter->napi, pskb);
+			rx_ok = _TRUE;
+#endif
 			goto next;
 		}
 #endif /* CONFIG_RTW_GRO */


### PR DESCRIPTION
The check on the return value of rtw_napi_gro_receive() is not necessary any more for kernels > v5.12.

There is another pull request #64 that checks whether return value is GRO_MERGED_FREE and treats that as an error condition. But I don't think that is the correct behavior, since the underlying kernel API dev_gro_receive(), defined in net/core/dev.c also returns that status in previous Linux versions (e.g., v5.11.21), and yet the driver did not treat it as an error conditions previously. This pull request should preserve the original semantics of the driver code.