### PR TITLE
Add RHEL >= 8 support

### DIFF
--- a/include/basic_types.h
+++ b/include/basic_types.h
@@ -72,6 +72,10 @@
 
 #ifdef PLATFORM_LINUX
 	#include <linux/version.h>
+	#ifndef RHEL_RELEASE_CODE
+		#define RHEL_RELEASE_VERSION(a,b) (((a) << 8) + (b))
+		#define RHEL_RELEASE_CODE 0
+	#endif
 	#include <linux/types.h>
 	#include <linux/module.h>
 	#include <linux/kernel.h>

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -16,6 +16,10 @@
 #define __OSDEP_SERVICE_H_
 
 #include <linux/version.h>
+#ifndef RHEL_RELEASE_CODE
+#define RHEL_RELEASE_VERSION(a,b) (((a) << 8 ) + (b))
+#define RHEL_RELEASE_CODE 0
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 #include <linux/sched/signal.h>
 #endif

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -16,6 +16,10 @@
 #define __OSDEP_LINUX_SERVICE_H_
 
 #include <linux/version.h>
+#ifndef RHEL_RELEASE_CODE
+#define RHEL_RELEASE_VERSION(a,b) (((a) << 8 ) + (b))
+#define RHEL_RELEASE_CODE 0
+#endif
 #include <linux/spinlock.h>
 #include <linux/compiler.h>
 #include <linux/kernel.h>

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -469,9 +469,11 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
 	}
 #endif
 
-    if (!rtw_cfg80211_allow_ch_switch_notify(adapter))
-        	goto exit;
-		cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
+	if (!rtw_cfg80211_allow_ch_switch_notify(adapter)) {
+		goto exit;
+	}
+
+	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
 
 #else
 	int freq = rtw_ch2freq(ch);
@@ -7613,7 +7615,7 @@ exit:
 	return ret;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0)
 static void cfg80211_rtw_update_mgmt_frame_register(struct wiphy *wiphy,
                                              struct wireless_dev *wdev,
                                              struct mgmt_frame_regs *upd)
@@ -10034,7 +10036,7 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
 	.mgmt_tx = cfg80211_rtw_mgmt_tx,
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0)
 	.update_mgmt_frame_registrations = cfg80211_rtw_update_mgmt_frame_register,
 #else
 	.mgmt_frame_register = cfg80211_rtw_mgmt_frame_register,

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1556,7 +1556,7 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0)
 	, struct net_device *sb_dev
 	#else
 	, void *accel_priv

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -663,7 +663,7 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		ret = -ENOMEM;
 		goto exit;
 	}
-	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)) || (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0))
 	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)) {
 	#else
 	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)) {

--- a/platform/platform_aml_s905_sdio.h
+++ b/platform/platform_aml_s905_sdio.h
@@ -16,6 +16,10 @@
 #define __PLATFORM_AML_S905_SDIO_H__
 
 #include <linux/version.h>	/* Linux vresion */
+#ifndef RHEL_RELEASE_CODE
+#define RHEL_RELEASE_VERSION(a,b) (((a) << 8 ) + (b))
+#define RHEL_RELEASE_CODE 0
+#endif
 
 extern void sdio_reinit(void);
 extern void extern_wifi_set_enable(int is_on);


### PR DESCRIPTION
Support for CentOS 8 and RHEL 8. Compiled and tested successfully on RHEL 8.4 kernel 4.18.0-305.