### PR TITLE
Fix for compilation error for linux kernel >=5.12 because of GRO_DROP deprecation

### DIFF
--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -355,8 +355,13 @@ static int napi_recv(_adapter *padapter, int budget)
 
 #ifdef CONFIG_RTW_GRO
 		if (pregistrypriv->en_gro) {
+			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0))
+			rtw_napi_gro_receive(&padapter->napi, pskb);
+			rx_ok = _TRUE;
+			#else
 			if (rtw_napi_gro_receive(&padapter->napi, pskb) != GRO_DROP)
 				rx_ok = _TRUE;
+			#endif
 			goto next;
 		}
 #endif /* CONFIG_RTW_GRO */


### PR DESCRIPTION
Fixed gro_drop compilation error on kernels >=5.12